### PR TITLE
chore: update partiql-cli to v1.4.0

### DIFF
--- a/partiql-cli.rb
+++ b/partiql-cli.rb
@@ -1,8 +1,8 @@
 class PartiqlCli < Formula
     desc "PartiQL CLI."
     homepage "https://partiql.org/"
-    url "https://github.com/partiql/partiql-lang-kotlin/releases/download/v1.2.2/partiql-cli-1.2.2.tgz"
-    sha256 "fc4b1508f1caec6522993e83d626ae0da619f42132f73c1f9ef389437862681b"
+    url "https://github.com/partiql/partiql-lang-kotlin/releases/download/v1.4.0/partiql-cli-1.4.0.tgz"
+    sha256 "9765c59a9f2977890585a8c4c5d698264bf85344c504e2079576822b2eee7b1f"
     license "Apache-2.0"
     depends_on "openjdk"
   


### PR DESCRIPTION
## Summary
- Updates the Homebrew formula for `partiql-cli` to v1.4.0

## Test plan
- [x] `brew tap johnedquinn/partiql && brew install johnedquinn/partiql/partiql-cli`
- [x] `partiql -V` → `PartiQL 1.4.0-6300ddfc8`
- [x] `partiql` REPL launches and evaluates `1 + 1;` → `2`